### PR TITLE
Memory Multiplier for EpsilonGreedy

### DIFF
--- a/dynamic_epsilon_script.py
+++ b/dynamic_epsilon_script.py
@@ -15,10 +15,12 @@ import matplotlib.pyplot as plt
 # Main Script
 if __name__ == "__main__":
     print("practice script py")
-    my_bandit = DynamicBandit(means=np.array([[10, 0],[0, 10], [9, 3]]),
-                              periods = [100, 100])
+    my_bandit = DynamicBandit(means=np.array([[10, 0],[0,10]]),
+                              periods = [200, 200])
     my_strategy = EpsilonGreedy(bandit = my_bandit, epsilon = 0.1)
-    out = my_strategy.fit(iterations=1000)
+    out = my_strategy.fit(iterations=1000, memory_multiplier = 0.9)
     print("Average Reward: " + str(np.mean(out['rewards'])))
+    plt.close()
     plt.plot(out['estimated_arm_means'].T)
-    
+    plt.show()
+

--- a/strategy.py
+++ b/strategy.py
@@ -5,28 +5,26 @@ class Strategy:
     """ Base Strategy Class
 
     Args:
-
-    Attributes:
-
+        bandit (Bandit): bandit to apply strategy on
+        **kwargs: additonal key-word arguments
 
     """
-
     def __init__(self, bandit, **kwargs):
         raise NotImplementedError
 
     def fit(self, iterations, **kwargs):
-        """ Fit
+        """ Fit Strategy on the current bandit
 
         Args:
-            iterations (int): number of lsjdflajdf
-            **kwargs: other
+            iterations (int): number of iterations to evaluate
+            **kwargs: additional key-word arguments
 
         Returns:
             A dictionary with arguments:
                 rewards (list): the values returned by the bandit
                                 at every iteration.
                 arms_pulled (list): the arm pulled at every iteration.
-                ...
+                ... : additional optional return values
         """
         raise NotImplementedError
 
@@ -88,13 +86,19 @@ class ThompsonGaussianKnownSigma(Strategy):
 
 class EpsilonGreedy(Strategy):
     """ Epislon Greedy Strategy
-    
+
+    Args:
+        bandit (Bandit): bandit of interest
+        epsilon (double): chance of random exploration vs exploitation
+            must be a value within [0,1]
+
     """
     def __init__(self, bandit, epsilon, **kwargs):
         self.bandit = bandit
+        if epsilon > 1 or epsilon < 0:
+            raise ValueError("epsilon {0} must be in [0,1]".format(epsilon))
         self.epsilon = epsilon
         self.arms_list = bandit.get_arms_list()
-#        self.estimate_arm_reward = np.zeros(self.arms_list.size)
         return
 
     def fit(self, iterations, **kwargs):
@@ -113,34 +117,39 @@ class EpsilonGreedy(Strategy):
         """
         assert(iterations >= len(self.arms_list))
         iteration = 0
-        
-        rewards_per_arm = [[] for i in range(len(self.arms_list))]
+
+        reward_sum_per_arm = np.zeros(len(self.arms_list))
+        reward_count_per_arm = np.zeros(len(self.arms_list))
+        estimated_arm_means = np.zeros((len(self.arms_list), iterations))
+
         rewards = [None] * iterations
         arms_pulled = [None] * iterations
-                      
-        estimated_arm_means = np.zeros((len(self.arms_list), iterations))
-        
+
 
         def pull_arm_index(arm_index, iteration):
             arm = self.arms_list[arm_index]
             reward = self.bandit.pull_arm(arm)
-            
+
             arms_pulled[iteration] = arm
             rewards[iteration] = reward
-            rewards_per_arm[arm_index].append(reward)
-            
-            estimated_arm_means[:,iteration] = np.array(
-                    [np.mean(a) for a in rewards_per_arm]
+            reward_sum_per_arm[arm_index] += reward
+            reward_count_per_arm[arm_index] += 1
+
+            nonzero_arms = reward_count_per_arm > 0
+            estimated_arm_means[nonzero_arms, iteration] = (
+                    reward_sum_per_arm[nonzero_arms] /
+                    reward_count_per_arm[nonzero_arms]
                     )
+            estimated_arm_means[~nonzero_arms, iteration] = np.nan
             return
-            
+
         # Pull each arm once
         scan_order = np.arange(len(self.arms_list))
         np.random.shuffle(scan_order)
         for arm_index in scan_order:
             pull_arm_index(arm_index, iteration)
             iteration += 1
-        
+
         # Epsilon Greedy
         while(iteration < iterations):
             if(np.random.rand() < self.epsilon):
@@ -148,14 +157,14 @@ class EpsilonGreedy(Strategy):
                 arm_index = np.random.randint(0, len(self.arms_list))
                 pull_arm_index(arm_index, iteration)
                 iteration += 1
-                
+
             else:
                 # Greedy
-                arm_index = np.argmax([np.mean(a) for a in rewards_per_arm])
+                arm_index = np.argmax(estimated_arm_means[:,iteration-1])
                 pull_arm_index(arm_index, iteration)
                 iteration += 1
-                
-            
+
+
         out_dict = dict(
                 rewards = rewards,
                 arms_pulled = arms_pulled,


### PR DESCRIPTION
I converted EpsilonGreedy to keep track of the sufficient statistics for the arm-means (sum and counts).
To allow for forgetfulness, I introduced a `memory_multiplier` parameter in fitting, which exponentially decays the sufficient statistics.

For example, if `memory_multiplier = 0.9`, then we 'forget' 10% of our data at each iteration.

An example is provided in 'dynamic_epsilon_script.py'.